### PR TITLE
Change API middleware to only check for a valid token

### DIFF
--- a/Http/apiRoutes.php
+++ b/Http/apiRoutes.php
@@ -3,10 +3,11 @@
 use Illuminate\Routing\Router;
 
 /** @var $router Router */
-$router->group(['prefix' => '/translation', 'middleware' => 'api.token.admin'], function (Router $router) {
+$router->group(['prefix' => '/translation', 'middleware' => 'api.token'], function (Router $router) {
     $router->post('update', [
         'uses' => 'TranslationController@update',
         'as' => 'api.translation.translations.update',
+        'middleware' => 'token-can:translation.translations.edit',
     ]);
     $router->post('clearCache', [
         'uses' => 'TranslationController@clearCache',


### PR DESCRIPTION
As per https://github.com/AsgardCms/Platform/issues/229, any API action
was limited to people in the "Admin" group. If the group name was changed
or the user wasn't an admin they couldn't do any API action at all, even
if they had correct permissions.
